### PR TITLE
Make backend use different type of databases

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -30,7 +30,10 @@ app.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x
 
 const io = require("socket.io")(httpServer, {
     cors: {
-        origin: "*",
+        origin: [
+            "http://localhost:5173",
+            "https://www.student.bth.se/~elmo22/editor"
+        ],
         methods: ["GET", "POST"]
     }
 });

--- a/backend/db/database.js
+++ b/backend/db/database.js
@@ -18,10 +18,12 @@ const database = {
     openDb: async function openDb() {
         try {
             let dbName = 'trains';
-
+            
             // Use test database when doing test
             if (process.env.NODE_ENV === 'test') {
                 dbName = 'test';
+            } else if (process.env.NODE_ENV === 'development') {
+                dbName = 'development';
             }
             const dsn = `mongodb+srv://${dbUser}:${dbPass}@jsramverk.a93x1lp.mongodb.net/` +
                 `${dbName}?retryWrites=true&w=majority`;

--- a/backend/db/database.js
+++ b/backend/db/database.js
@@ -18,8 +18,8 @@ const database = {
     openDb: async function openDb() {
         try {
             let dbName = 'trains';
-            
-            // Use test database when doing test
+
+            // Use test database when doing test or a development db if in development
             if (process.env.NODE_ENV === 'test') {
                 dbName = 'test';
             } else if (process.env.NODE_ENV === 'development') {

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
-    "dev": "NODE_ENV=development nodemon app.js",
+    "start-test": "NODE_ENV=test node app.js",
+    "start-dev": "NODE_ENV=development nodemon app.js",
     "eslint": "eslint .",
     "test": "NODE_ENV=test nyc --reporter=html --reporter=text mocha --exit 'test/**/*.js' --timeout 10000"
   },

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node app.js",
     "dev": "NODE_ENV=development nodemon app.js",
     "eslint": "eslint .",
-    "test": "nyc --reporter=html --reporter=text mocha --exit 'test/**/*.js' --timeout 10000"
+    "test": "NODE_ENV=test nyc --reporter=html --reporter=text mocha --exit 'test/**/*.js' --timeout 10000"
   },
   "keywords": [],
   "author": "",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
-    "start-dev": "nodemon app.js",
+    "dev": "NODE_ENV=development nodemon app.js",
     "eslint": "eslint .",
     "test": "nyc --reporter=html --reporter=text mocha --exit 'test/**/*.js' --timeout 10000"
   },


### PR DESCRIPTION
Har nu lagt in så att den sätter NODE_ENV till 'test' när man antingen kör 'npm run test'  och 'npm run start-test' eller sätter NODE_ENV='development' när man kör 'npm run start-dev'. Det har fungerat lokalt för mig när jag har provat.

Har också ändrat cors till att fungera med 'http://localhost:5173' och 'https://www.student.bth.se/~elmo22/editor'.