### PR TITLE
Add script update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ The application can be found here: [Train-controller](https://www.student.bth.se
 bash setup_app.bash
 ```
 
-A a .env file is needed in the /backend folder with API-key, see *.env.example* for structure.
+An .env file is needed in the /backend folder with API-key, see *.env.example* for structure.
 
-When developing this repo both the backend and frontend locally needs to be started locally. This will run backend and frontend in the development environment, which won't effect the database used in the deployed application. When starting frontend in development the URL 'localhost:1337' is used to fetch data, where backend then uses it's own database 'development' in the Atlas Cloud.
+When developing, both, the backend and frontend, need to be started locally. This will run backend and frontend in the development environment, which won't effect the database used in the deployed application. When starting frontend in development the URL 'localhost:1337' is used to fetch data, where backend then uses it's own database 'development' in the Atlas Cloud.
 
 ```
 # Run backend from /backend folder
@@ -49,17 +49,17 @@ npm run test
 
 #### Frontend (Vue)
 
-For frontend testing cypress is used for end to end testing. Testing uses the API and also the 'test' database in the Atlas Cloud. Therefor the backend needs to be started locally in 'test-mode'. To run the test the commands below is needed to be run, which is also the way it's done during continuous integration.
+For frontend testing cypress is used for end to end testing. Testing uses the API and also the 'test' database in the Atlas Cloud. The backend needs to be started locally in 'test-mode'. To run the test the commands below is needed to be run, which is also the way it's done during continuous integration.
 
 ```
 # Stand in /backend folder.
 npm run start-test
 
-# Start the front-end server from /fronend-vue
+# Start the front-end server from /frontend-vue
 npm run dev
 
 # Then run the test from /frontend-vue
-npm run cy:run
+npm run cy:run --e2e
 ```
 
 ### Deploying the app
@@ -68,7 +68,7 @@ The backend is deployed in the Azure Cloud, and can be found here: [Backend](htt
 Deploying the frontend is done with rsync and put on the BTH:s student server. Using Vue and vue-router a root specific root needs to be setup before deploying the application. In the '/frontend-vue/src/router/index.js' the 'createWebHistory()' needs to have the correct root. In our case '/~elmo22/train/'. The deployed application can be found here: [Frontend](https://www.student.bth.se/~elmo22/train/).
 
 ```
-# Deploy the frontend from /fronend-vue
+# Deploy the frontend from /frontend-vue
 npm run deploy
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This is the repository for the course *jsramverk* (h23).
 It is maintained by *elmo22* and *poak22*.
 
+The application can be found here: [Train-controller](https://www.student.bth.se/~elmo22/train/). And the backend can be found here: [Backend](https://jsramverk-train-poak22-elmo22.azurewebsites.net/).
+
 ## How to use this repo
 
 ```
@@ -59,6 +61,17 @@ npm run dev
 # Then run the test from /frontend-vue
 npm run cy:run
 ```
+
+### Deploying the app
+The backend is deployed in the Azure Cloud, and can be found here: [Backend](https://jsramverk-train-poak22-elmo22.azurewebsites.net/).
+
+Deploying the frontend is done with rsync and put on the BTH:s student server. Using Vue and vue-router a root specific root needs to be setup before deploying the application. In the '/frontend-vue/src/router/index.js' the 'createWebHistory()' needs to have the correct root. In our case '/~elmo22/train/'. The deployed application can be found here: [Frontend](https://www.student.bth.se/~elmo22/train/).
+
+```
+# Deploy the frontend from /fronend-vue
+npm run deploy
+```
+
 
 ## Steps to make backend work locally from original repo
 

--- a/README.md
+++ b/README.md
@@ -38,14 +38,16 @@ Test can be run for both backend and frontend.
 
 #### Backend
 
+For testing the backend mocha is used for together with chai. Testing is done on a own database called 'test' that is setup in the Atlas Cloud. The command below is also the command used in github actions for continuous integration.
+
 ```
 # Stand in /backend folder.
 npm run test
 ```
 
-#### Frontend
+#### Frontend (Vue)
 
-You need to start the backend in the test enviroment.
+For testing the frontend cypress is used for end to end testing. Testing uses the api and also the 'test' database in the Atlas Cloud. Therefor the backend needs to be started locally in 'test-mode'. To run the test the commands below is needed to be run, which is also the way it's done during continuous integration.
 
 ```
 # Stand in /backend folder.
@@ -55,7 +57,7 @@ npm run start-test
 npm run dev
 
 # Then run the test from /frontend-vue
-npm run cy:run
+npm run cy:run --e2e
 ```
 
 ## Steps to make backend work locally from original repo

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Repository *jsramverk-train-controller*
+
 This is the repository for the course *jsramverk* (h23).
 It is maintained by *elmo22* and *poak22*.
+
+## How to use this repo
 
 ```
 # To initialze the application you need to run the following script from root folder in repo.
@@ -9,9 +12,55 @@ bash setup_app.bash
 
 You also need a .env file in the /backend folder with API-key, see *.env.example* for structure.
 
-## Backend
+When developing in this repo you will need start both the backend and frontend locally. This will run backend and frontend in the development environment, which won't effect the database used in the deployed application.
 
-### Steps to make backend work locally from original repo
+```
+# Run backend from /backend folder
+npm run start-dev
+```
+
+```
+# Run frontend from /frontend-vue folder
+npm run dev
+```
+### Reset development database
+
+If needed during development, you can reset the database.
+
+```
+# To reset the development database, stand in /backend folder.
+npm run dev-reset-db
+```
+
+### Tests
+
+Test can be run for both backend and frontend.
+
+#### Backend
+
+```
+# Stand in /backend folder.
+npm run test
+```
+
+#### Frontend
+
+You need to start the backend in the test enviroment.
+
+```
+# Stand in /backend folder.
+npm run start-test
+
+# Start the front-end server from /fronend-vue
+npm run dev
+
+# Then run the test from /frontend-vue
+npm run cy:run
+```
+
+## Steps to make backend work locally from original repo
+
+### Backend
 
 Created account [Trafikverket](https://api.trafikinfo.trafikverket.se/) to receive a personal API key, then create an .env file, following the template in .env.example, and store your API key in that file.
 
@@ -27,14 +76,14 @@ npm install
 bash db/reset_db.bash
 ```
 
-### Start app
+#### Start app
 
 ```
-# To run the app from /backend folder
+# To run the app from /backend folder (using a npm-script)
 npm run start-dev
 ```
 
-### Run a security audit
+#### Run a security audit
 
 To check our app for vulnerabilities, run an *npm audit*. For help, check the [documentation](https://docs.npmjs.com/cli/v6/commands/npm-audit).
 
@@ -108,9 +157,9 @@ Running *npm audit fix* after changing package.json manually added 7 packages, r
 [^3]: https://portswigger.net/web-security/prototype-pollution, last visited 2023-08-30.
 
 
-## Frontend
+### Frontend
 
-### Start app
+#### Start app
 
 ```
 # To run the app on *http://localhost:9000/*

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ It is maintained by *elmo22* and *poak22*.
 ## How to use this repo
 
 ```
-# To initialze the application you need to run the following script from root folder in repo.
+# To initialze the application, run the following script from root folder in repo.
 bash setup_app.bash
 ```
 
-You also need a .env file in the /backend folder with API-key, see *.env.example* for structure.
+A a .env file is needed in the /backend folder with API-key, see *.env.example* for structure.
 
-When developing in this repo you will need start both the backend and frontend locally. This will run backend and frontend in the development environment, which won't effect the database used in the deployed application.
+When developing in this repo both the backend and frontend locally needs to be started locally. This will run backend and frontend in the development environment, which won't effect the database used in the deployed application since the frontend in will use 'localhost:1337' when sending request to the API.
 
 ```
 # Run backend from /backend folder
@@ -25,7 +25,7 @@ npm run dev
 ```
 ### Reset development database
 
-If needed during development, you can reset the database.
+If needed during development, the development database can be reset.
 
 ```
 # To reset the development database, stand in /backend folder.
@@ -38,7 +38,7 @@ Test can be run for both backend and frontend.
 
 #### Backend
 
-For testing the backend mocha is used for together with chai. Testing is done on a own database called 'test' that is setup in the Atlas Cloud. The command below is also the command used in github actions for continuous integration.
+Mocha together with chai is used for backend testing. Testing is done on a it's own database called 'test' that is setup in the Atlas Cloud. The command below is also the command used in github actions for continuous integration.
 
 ```
 # Stand in /backend folder.
@@ -47,7 +47,7 @@ npm run test
 
 #### Frontend (Vue)
 
-For testing the frontend cypress is used for end to end testing. Testing uses the api and also the 'test' database in the Atlas Cloud. Therefor the backend needs to be started locally in 'test-mode'. To run the test the commands below is needed to be run, which is also the way it's done during continuous integration.
+For frontend testing cypress is used for end to end testing. Testing uses the API and also the 'test' database in the Atlas Cloud. Therefor the backend needs to be started locally in 'test-mode'. To run the test the commands below is needed to be run, which is also the way it's done during continuous integration.
 
 ```
 # Stand in /backend folder.
@@ -57,7 +57,7 @@ npm run start-test
 npm run dev
 
 # Then run the test from /frontend-vue
-npm run cy:run --e2e
+npm run cy:run
 ```
 
 ## Steps to make backend work locally from original repo

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ bash setup_app.bash
 
 A a .env file is needed in the /backend folder with API-key, see *.env.example* for structure.
 
-When developing in this repo both the backend and frontend locally needs to be started locally. This will run backend and frontend in the development environment, which won't effect the database used in the deployed application since the frontend in will use 'localhost:1337' when sending request to the API.
+When developing this repo both the backend and frontend locally needs to be started locally. This will run backend and frontend in the development environment, which won't effect the database used in the deployed application. When starting frontend in development the URL 'localhost:1337' is used to fetch data, where backend then uses it's own database 'development' in the Atlas Cloud.
 
 ```
 # Run backend from /backend folder
@@ -38,7 +38,7 @@ Test can be run for both backend and frontend.
 
 #### Backend
 
-Mocha together with chai is used for backend testing. Testing is done on a it's own database called 'test' that is setup in the Atlas Cloud. The command below is also the command used in github actions for continuous integration.
+Mocha together with chai is used for backend testing. Testing is done on a it's own database called 'test' that is set-up in the Atlas Cloud. The command below is also the command used in github actions for continuous integration.
 
 ```
 # Stand in /backend folder.

--- a/backend/app.js
+++ b/backend/app.js
@@ -32,8 +32,8 @@ const io = require("socket.io")(httpServer, {
     cors: {
         origins: [
             "http://localhost:5173",
-            "https://www.student.bth.se/~elmo22/editor",
-            "https://www.student.bth.se/~poak22/editor"
+            "https://www.student.bth.se/~elmo22/train",
+            "https://www.student.bth.se/~poak22/train"
         ],
         methods: ["GET", "POST"]
     }

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "start-test": "NODE_ENV=test node app.js",
     "start-dev": "NODE_ENV=development nodemon app.js",
     "eslint": "eslint .",
+    "dev-reset-db": "NODE_ENV=development node db/setup.js",
     "test": "NODE_ENV=test nyc --reporter=html --reporter=text mocha --exit 'test/**/*.js' --timeout 10000"
   },
   "keywords": [],

--- a/frontend-vue/.env.development
+++ b/frontend-vue/.env.development
@@ -1,2 +1,3 @@
 # .env.development
 VITE_BASE_URL="http://localhost:1337"
+VITE_ROUTER_ROOT=""

--- a/frontend-vue/.env.production
+++ b/frontend-vue/.env.production
@@ -1,2 +1,3 @@
 # .env.production
 VITE_BASE_URL="https://jsramverk-train-poak22-elmo22.azurewebsites.net"
+VITE_ROUTER_ROOT="/~elmo22/train/"

--- a/frontend-vue/package.json
+++ b/frontend-vue/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "deploy": "npm run build && rsync -av --delete dist/ elmo22@ssh.student.bth.se:www/editor",
+    "deploy": "npm run build && rsync -av --delete dist/ elmo22@ssh.student.bth.se:www/train",
     "preview": "vite preview",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore",
     "format": "prettier --write src/",

--- a/frontend-vue/src/router/index.js
+++ b/frontend-vue/src/router/index.js
@@ -19,8 +19,9 @@ const routes = [
 ]
 
 // Router
+// Router root is "" when in development and "/~elmo22/train/" in production
 const router = createRouter({
-  history: createWebHistory(),
+history: createWebHistory(import.meta.env.VITE_ROUTER_ROOT),
   routes: routes
 })
 

--- a/setup_app.bash
+++ b/setup_app.bash
@@ -1,6 +1,8 @@
+#!/usr/bin/env bash
+#
+# Just a simple script to set up the application when cloning repo
+#
 cd backend
 npm install
-bash db/reset_db.bash
-# Uncomment lines below when using npm in frontend
-# cd ../frontend
-# npm install
+cd ../frontend-vue
+npm install


### PR DESCRIPTION
Har uppdaterat texten nu, se över om du tycker det är bra eller om jag borde ändra något.

Jag la också till VITE_ROUTER_ROOT i .env filerna som använder din akronym när man kör deploy så du inte ska behöva göra något mer än att som tidigare köra 'npm run deploy'. Och så ändrade jag från editor till train när du kör det kommandot. Samt att jag ändrade 'cors' for io i backend så det också har train.

Gjorde om så att setup_bash installerar frontend och backend men återställer inte databasen. Gjorde ett eget kommando för det 'npm run dev-reset-db' så att man lite lättare kunde köra det under utveckling.